### PR TITLE
ci: allow multiple symbol defs at agent test link

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -157,10 +157,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}"
+          make -r -s -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
         else
           printf 'running agent unit tests\n'
-          make -r -s -j $(nproc) agent-check "ARCH=${ARCH}"
+          make -r -s -j $(nproc) agent-check "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
         fi
 	;;
       *)


### PR DESCRIPTION
PHP embed SAPI (libphp) embedes PCRE library. So does axiom library.
Agent unit tests require both: PHP embed SAPI and axiom library. PHPs
5.5, 5.6, 7.0, 7.1, and 7.2 embed older version of PCRE and this causes
linker to find PCRE symbols in two places: PHP embed SAPI (libphp) and
axiom library. This causes the linker to report a fatal error and abort.
This change allows for multiple definitions and the first definition
found will be used.

Note: PHP embed SAPIs 7.3+ come with PCRE2, which uses different symbol
names and does not create conflict with PCRE embeded in axiom library.