### PR TITLE
ci: allow multiple symbol defs at agent test link

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -157,10 +157,10 @@ EOF
       *embed*)
         if [ -n "$do_valgrind" ]; then
           printf 'grinding agent unit tests\n'
-          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
+          make -r -j $(nproc) agent-valgrind "ARCH=${ARCH}" USER_LDFLAGS='-Wl,-z,muldefs'
         else
           printf 'running agent unit tests\n'
-          make -r -j $(nproc) agent-check "ARCH=${ARCH}" LDFLAGS='-Wl,-z,muldefs'
+          make -r -j $(nproc) agent-check "ARCH=${ARCH}" USER_LDFLAGS='-Wl,-z,muldefs'
         fi
 	;;
       *)

--- a/agent/Makefile.frag
+++ b/agent/Makefile.frag
@@ -261,6 +261,7 @@ endif
 #
 TEST_LIBS := $(PHP_EMBED_LIBRARY) $(shell $(PHP_CONFIG) --libs)
 TEST_LDFLAGS := $(shell $(PHP_CONFIG) --ldflags) $(EXPORT_DYNAMIC)
+TEST_LDFLAGS += $(USER_LDFLAGS)
 
 #
 # Implicit rule to build test object files with the appropriate flags.


### PR DESCRIPTION
LDFLAGS cannot be set with make command argument because it overrides
its value defined in Makefile. This causes `-pthread` to be removed from
LDFLAGS and as a result test binary cannot be built because pthread
symbols are unresolved (no pthread library provided in the link command).
A new variable USER_LDFLAGS is introduced as a workaround for this issue.