### PR TITLE
ci: enable integration tests in pr build workflow

### DIFF
--- a/.github/docker/linux/pr_build.sh
+++ b/.github/docker/linux/pr_build.sh
@@ -141,8 +141,8 @@ EOF
     ;;
   *)
     printf "Running agent integration tests (PHP=%s ZTS=disabled)\n" "$PHPS"
-    printf "Temporarily disable integration tests in GHA while determining what to do with private keys.\n"
-    #make integration PHPS="$PHPS" "ARCH=${ARCH}" INTEGRATION_ARGS="--retry=1"
+    #printf "Temporarily disable integration tests in GHA while determining what to do with private keys.\n"
+    make integration PHPS="$PHPS" "ARCH=${ARCH}" INTEGRATION_ARGS="tests/integration/api/datastore/test_basic.php"
     ;;
   esac
   printf \\n


### PR DESCRIPTION
Once it is determined it works, `Integration-CentOS` and `Integration-Alpine` jobs can be removed from pr-build.yml workflow.